### PR TITLE
Add registration config information

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ After being first registered, you need to execute the folloing command to promot
 
 and respond yes to the question ` Add admin privileges to this user?`
 
+### Allow/Close registration
+
+Registrations are open by default.
+To change that setting, edit `/var/www/pixelfed/.env` and set `OPEN_REGISTRATION=false` instead of `true`.
+
 ## Documentation
 
  * [Official documentation](https://docs.pixelfed.org/master/)


### PR DESCRIPTION
Some people might want to change the registration to false, for instance after creating their (single user instance) account.
This give them an easier way to figure out how to do it.

Related to #24 