### PR TITLE
Remove ugly move needed before yunohost 3.5.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "description": {
         "en": "ActivityPub Federated Image Sharing"
     },
-    "version": "0.8.4~ynh3",
+    "version": "0.8.4~ynh4",
     "url": "https://pixelfed.org/",
     "license": "AGPL-3.0-or-later",
     "maintainer": {
@@ -13,7 +13,7 @@
         "email": "jean-baptiste@holcroft.fr"
     },
     "requirements": {
-        "yunohost": ">= 3.4"
+        "yunohost": ">= 3.5"
     },
     "multi_instance": true,
     "services": [

--- a/scripts/install
+++ b/scripts/install
@@ -106,11 +106,6 @@ ynh_print_info "Configuring php-fpm..."
 # Create a dedicated php-fpm config
 ynh_add_fpm_config --phpversion="7.2"
 
-#Ugly move waiting 'ynh_add_fpm_config --phpversion='' released
-mv "/etc/php/7.0/fpm/pool.d/$app.conf" "/etc/php/7.2/fpm/pool.d/$app.conf"
-systemctl reload php7.0-fpm
-systemctl reload php7.2-fpm
-
 #=================================================
 # INSTALL PHP DEPENDENCIES
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -47,11 +47,6 @@ ynh_remove_nginx_config
 #=================================================
 ynh_print_info "Removing php-fpm configuration"
 
-#Ugly move waiting 'ynh_add_fpm_config --phpversion='' released
-mv "/etc/php/7.2/fpm/pool.d/$app.conf" "/etc/php/7.0/fpm/pool.d/$app.conf"
-systemctl reload php7.2-fpm
-systemctl reload php7.0-fpm
-
 # Remove the dedicated php-fpm config
 ynh_remove_fpm_config
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -116,20 +116,8 @@ ynh_system_user_create "$app"
 #=================================================
 ynh_print_info "Upgrading php-fpm configuration..."
 
-#Ugly move waiting 'ynh_add_fpm_config --phpversion='' released
-mv -f "/etc/php/7.2/fpm/pool.d/$app.conf" "/etc/php/7.0/fpm/pool.d/$app.conf"
-sleep 5
-systemctl reload php7.2-fpm
-systemctl reload php7.0-fpm
-
 # Create a dedicated php-fpm config
 ynh_add_fpm_config --phpversion="7.2"
-
-#Ugly move waiting 'ynh_add_fpm_config --phpversion='' released
-mv -f "/etc/php/7.0/fpm/pool.d/$app.conf" "/etc/php/7.2/fpm/pool.d/$app.conf"
-sleep 5
-systemctl reload php7.0-fpm
-systemctl reload php7.2-fpm
 
 #=================================================
 # SPECIFIC UPGRADE


### PR DESCRIPTION
## Problem
- *Installation on Yunohost 3.5.2 failed*

## Solution
- *Removing ugly moves implemented when `ynh_add_fpm_config` argument `--phpversion=` wasn't available*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
- [ ] **Code review**
- [ ] **Approval (LGTM)**  
*Code review and approval have to be from a member of @YunoHost/apps group*
- **CI succeeded** : On Yunohost 3.5.2

![Capture](https://user-images.githubusercontent.com/30271971/55918069-04aa6580-5bf2-11e9-881a-64455d91af1b.PNG)


![Capture](https://user-images.githubusercontent.com/30271971/55918034-e5133d00-5bf1-11e9-9d58-15cf8fd61e71.PNG)

