### PR TITLE
Add config instructions about php commands and php version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ The federated image sharing service Pixelfed, for YunoHost
 ![](https://camo.githubusercontent.com/c1c2e74057dcff57e103fcbb3239840802fcf752/68747470733a2f2f706978656c6665642e6e7963332e63646e2e6469676974616c6f6365616e7370616365732e636f6d2f6d656469612f53637265656e25323053686f74253230323031392d30322d30352532306174253230362e33342e3539253230504d2e706e67)
 
 ## Configuration
-[Official documentation](https://docs.pixelfed.org/master/configuration.html)
 
 ### Administrator
 
@@ -28,15 +27,17 @@ After being first registered, you need to execute the folloing command to promot
 
 and respond yes to the question ` Add admin privileges to this user?`
 
-### Pixelfed php commands and php version
-
-Pixelfed might require some command line instructions if you make manual changes to your configuration.
-By default php 7.0 is currently used when you type `php`. You need to use `php7.2 [command]` instead.
-
 ### Allow/Close registration
 
 Registrations are open by default.
 To change that setting, edit `/var/www/pixelfed/.env` and set `OPEN_REGISTRATION=false` instead of `true`.
+Then run `php7.2 artisan config:cache` to reload the settings.
+
+### Pixelfed php commands and php version
+
+Pixelfed might require some command line instructions if you want to make manual changes to your configuration.
+By default php 7.0 is currently used when you type `php`. You need to use `php7.2 [command]` instead.
+Those commands can be found in the official documentation.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The federated image sharing service Pixelfed, for YunoHost
 ![](https://camo.githubusercontent.com/c1c2e74057dcff57e103fcbb3239840802fcf752/68747470733a2f2f706978656c6665642e6e7963332e63646e2e6469676974616c6f6365616e7370616365732e636f6d2f6d656469612f53637265656e25323053686f74253230323031392d30322d30352532306174253230362e33342e3539253230504d2e706e67)
 
 ## Configuration
+[Official documentation](https://docs.pixelfed.org/master/configuration.html)
 
 ### Administrator
 
@@ -26,6 +27,11 @@ After being first registered, you need to execute the folloing command to promot
     $ (cd /var/www/pixelfed && php7.2 artisan user:admin 1)
 
 and respond yes to the question ` Add admin privileges to this user?`
+
+### Pixelfed php commands and php version
+
+Pixelfed might require some command line instructions if you make manual changes to your configuration.
+By default php 7.0 is currently used when you type `php`. You need to use `php7.2 [command]` instead.
 
 ### Allow/Close registration
 


### PR DESCRIPTION
## Problem
- Default php syntax use the wrong version. This is confusing.
See https://github.com/YunoHost-Apps/pixelfed_ynh/issues/48#issuecomment-497235849

## Solution
- Explain which php version to use and how.

## PR Status
- [x] Code finished.
- [x] Can be reviewed and tested.

## Validation
---
- [ ] **Code review**
- [ ] **Approval (LGTM)**  