### PR TITLE
Increase file size upload limit

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -12,7 +12,7 @@ location __PATH__/ {
     index index.php;
 
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
-  #client_max_body_size 50M;
+  client_max_body_size 20M;
 
   location ~ [^/]\.php(/|$) {
     fastcgi_split_path_info ^(.+?\.php)(/.*)$;


### PR DESCRIPTION
## Problem
- Nginx upload limit is too low, image of at least 1.6MB can't be uploaded.
https://github.com/YunoHost-Apps/pixelfed_ynh/pull/61#issuecomment-499389970

## Solution
- Increase the limit
For the value, I don't really not what's meaningful… I believe most JPG images will be under 10MB, but PNG might be bigger, and stuff like loops and panorama images might be bigger… I'd suggest 20MB as a maximum (even if it's not really reasonable for a web picture to be that big)

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
- [ ] **Code review**
- [ ] **Approval (LGTM)**  
*Code review and approval have to be from a member of @YunoHost/apps group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/pixelfed_ynh%20-BRANCH-/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/pixelfed_ynh%20-BRANCH-/)  
*Please replace '-BRANCH-' in this link by the name of the branch used.*  
*If the PR is from a forked repository. Please provide public results from package_check.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
