### PR TITLE
Use new federation variables

### DIFF
--- a/conf/.env
+++ b/conf/.env
@@ -48,9 +48,9 @@ MAX_CAPTION_LENGTH=150
 MAX_ALBUM_LENGTH=4
 
 ACTIVITY_PUB=true
-REMOTE_FOLLOW=true
-ACTIVITYPUB_INBOX=true
-ACTIVITYPUB_SHAREDINBOX=true
+AP_REMOTE_FOLLOW=true
+AP_INBOX=true
+AP_SHAREDINBOX=true
 
 # Set these "true" to enable federation.
 # You might need to also run:


### PR DESCRIPTION
## Problem
- `.env` parameters for federation are outdated.
https://github.com/pixelfed/support/issues/57#issuecomment-544187772
>  `REMOTE_FOLLOW` has become `AP_REMOTE_FOLLOW`, and `ACTIVITYPUB_INBOX` has become `AP_INBOX`.
## Solution
- Change them.

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/pixelfed_ynh%20PR87%20(yalh76)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/pixelfed_ynh%20PR87%20(yalh76)/)  
