### PR TITLE
Use new federation variables

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "en": "ActivityPub Federated Image Sharing",
     "fr": "Logiciel de partage d'image fédéré via ActivityPub"
   },
-  "version": "0.10.6~ynh1",
+  "version": "0.10.6~ynh2",
   "url": "https://pixelfed.org/",
   "license": "AGPL-3.0-or-later",
   "maintainer": [


### PR DESCRIPTION
## Problem
- `.env` parameters for federation are outdated.
https://github.com/pixelfed/support/issues/57#issuecomment-544187772
>  `REMOTE_FOLLOW` has become `AP_REMOTE_FOLLOW`, and `ACTIVITYPUB_INBOX` has become `AP_INBOX`.
## Solution
- Change them.

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/pixelfed_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/pixelfed_ynh%20PR-NUM-%20(USERNAME)/)  
