### PR TITLE
v0.11.2 + change php version to 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In addition to taking over the functionality of Instagram, the functioning of Pi
 
 It is also possible to import your data from Instagram. 
 
-**Shipped version:** 0.11.1~ynh2
+**Shipped version:** 0.11.2~ynh1
 
 
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ En plus de reprendre les fonctionnalités d'Instagram, le fonctionnement de Pixe
 Il est également possible d'importer ses données depuis Instagram.
 
 
-**Version incluse :** 0.11.1~ynh2
+**Version incluse :** 0.11.2~ynh1
 
 
 

--- a/check_process
+++ b/check_process
@@ -32,6 +32,8 @@
 		upgrade=1	from_commit=c7181d1c7cb6cba53bb65e622c78b0309a53b76a
 		# 0.11.0~ynh2
 		upgrade=1	from_commit=d85b0b112afd19313dbf4cfba954e255789dfb88
+		# 0.11.1~ynh2
+		upgrade=1	from_commit=f8ecb9a95fe6430fb9d93ca674e4f0d475ecd332
 		backup_restore=1
 		multi_instance=1
 		port_already_use=0
@@ -58,3 +60,5 @@ Notification=all
 		name=0.11.0~ynh1
 	; commit=d85b0b112afd19313dbf4cfba954e255789dfb88
 		name=0.11.0~ynh2
+	; commit=f8ecb9a95fe6430fb9d93ca674e4f0d475ecd332
+		name=0.11.1~ynh2

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/pixelfed/pixelfed/archive/v0.11.1.tar.gz
-SOURCE_SUM=132dfceac3c0ea27dd54198d145d2d84f1714b4aa333c8b6f5141d259a77e9cb
+SOURCE_URL=https://github.com/pixelfed/pixelfed/archive/v0.11.2.tar.gz
+SOURCE_SUM=04eca99fa8a725ae97cf01ad8c8b26b28f02a2b579dcff9320a172433afe0de2
 OURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "ActivityPub Federated Image Sharing",
         "fr": "Logiciel de partage d'image fédéré via ActivityPub"
     },
-    "version": "0.11.1~ynh2",
+    "version": "0.11.2~ynh1",
     "url": "https://pixelfed.org/",
     "upstream": {
         "license": "AGPL-3.0-or-later",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,7 +8,9 @@ YNH_PHP_VERSION="7.4"
 
 YNH_COMPOSER_VERSION="2.1.5"
 
-pkg_dependencies="postgresql libgd3 jpegoptim optipng pngquant ffmpeg imagemagick supervisor php${YNH_PHP_VERSION}-bcmath php${YNH_PHP_VERSION}-cli php${YNH_PHP_VERSION}-ctype php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-exif php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-iconv php${YNH_PHP_VERSION}-intl php${YNH_PHP_VERSION}-json php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-redis php${YNH_PHP_VERSION}-tokenizer php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-zip php${YNH_PHP_VERSION}-pdo php${YNH_PHP_VERSION}-pgsql php${YNH_PHP_VERSION}-fileinfo php${YNH_PHP_VERSION}-imagick"
+pkg_dependencies="postgresql libgd3 jpegoptim optipng pngquant ffmpeg imagemagick supervisor"
+
+extra_php_dependencies="php${YNH_PHP_VERSION}-bcmath php${YNH_PHP_VERSION}-cli php${YNH_PHP_VERSION}-ctype php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-exif php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-iconv php${YNH_PHP_VERSION}-intl php${YNH_PHP_VERSION}-json php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-redis php${YNH_PHP_VERSION}-tokenizer php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-zip php${YNH_PHP_VERSION}-pdo php${YNH_PHP_VERSION}-pgsql php${YNH_PHP_VERSION}-fileinfo php${YNH_PHP_VERSION}-imagick"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,7 @@
 # COMMON VARIABLES
 #=================================================
 
-YNH_PHP_VERSION="7.3"
+YNH_PHP_VERSION="7.4"
 
 YNH_COMPOSER_VERSION="2.1.5"
 

--- a/scripts/config
+++ b/scripts/config
@@ -89,7 +89,7 @@ ynh_app_config_validate() {
 ynh_app_config_apply() {
     _ynh_app_config_apply
 
-    ynh_add_fpm_config --phpversion=$phpversion --usage=$fpm_usage --footprint=$fpm_footprint
+    ynh_add_fpm_config --phpversion=$phpversion --usage=$fpm_usage --footprint=$fpm_footprint --package="$extra_php_dependencies"
 }
 
 ynh_app_config_run $1

--- a/scripts/install
+++ b/scripts/install
@@ -115,7 +115,7 @@ ynh_add_nginx_config
 ynh_script_progression --message="Configuring PHP-FPM..."
 
 # Create a dedicated PHP-FPM config
-ynh_add_fpm_config --usage=low --footprint=low
+ynh_add_fpm_config --usage=low --footprint=low --package="$extra_php_dependencies"
 phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -92,7 +92,8 @@ ynh_script_progression --message="Restoring PHP-FPM configuration..."
 ynh_restore_file --origin_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 
 # Recreate a dedicated php-fpm config
-ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint --phpversion=$phpversion
+ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint --phpversion=$phpversion --package="$extra_php_dependencies"
+phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 
 #=================================================
 # RESTORE THE POSTGRESQL DATABASE

--- a/scripts/restore
+++ b/scripts/restore
@@ -75,16 +75,6 @@ chmod -R o-rwx "$final_path"
 chown -R $app:www-data "$final_path"
 
 #=================================================
-# RESTORE THE PHP-FPM CONFIGURATION
-#=================================================
-ynh_script_progression --message="Restoring PHP-FPM configuration..."
-
-ynh_restore_file --origin_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
-
-# Recreate a dedicated php-fpm config
-ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint --phpversion=$phpversion
-
-#=================================================
 # SPECIFIC RESTORATION
 #=================================================
 # REINSTALL DEPENDENCIES
@@ -93,6 +83,16 @@ ynh_script_progression --message="Reinstalling dependencies..."
 
 # Define and install dependencies
 ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
+
+#=================================================
+# RESTORE THE PHP-FPM CONFIGURATION
+#=================================================
+ynh_script_progression --message="Restoring PHP-FPM configuration..."
+
+ynh_restore_file --origin_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
+
+# Recreate a dedicated php-fpm config
+ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint --phpversion=$phpversion
 
 #=================================================
 # RESTORE THE POSTGRESQL DATABASE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -173,19 +173,19 @@ ynh_script_progression --message="Upgrading NGINX web server configuration..."
 ynh_add_nginx_config
 
 #=================================================
-# UPGRADE DEPENDENCIES
-#=================================================
-ynh_script_progression --message="Upgrading dependencies..."
-
-ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
-
-#=================================================
 # PHP-FPM CONFIGURATION
 #=================================================
 ynh_script_progression --message="Upgrading PHP-FPM configuration..."
 
 # Create a dedicated PHP-FPM config
 ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint
+
+#=================================================
+# UPGRADE DEPENDENCIES
+#=================================================
+ynh_script_progression --message="Upgrading dependencies..."
+
+ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================
 # SPECIFIC UPGRADE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -185,7 +185,8 @@ ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
 ynh_script_progression --message="Upgrading PHP-FPM configuration..."
 
 # Create a dedicated PHP-FPM config
-ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint
+ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint --package="$extra_php_dependencies"
+phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 
 #=================================================
 # SPECIFIC UPGRADE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -25,7 +25,6 @@ db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 db_user=$db_name
 db_pwd=$(ynh_app_setting_get --app=$app --key=psqlpwd)
 app_key=$(ynh_app_setting_get --app=$app --key=app_key)
-phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 redis_db=$(ynh_app_setting_get --app=$app --key=redis_db)
 
 fpm_footprint=$(ynh_app_setting_get --app=$app --key=fpm_footprint)
@@ -186,7 +185,7 @@ ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
 ynh_script_progression --message="Upgrading PHP-FPM configuration..."
 
 # Create a dedicated PHP-FPM config
-ynh_add_fpm_config --phpversion=$phpversion --usage=$fpm_usage --footprint=$fpm_footprint
+ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint
 
 #=================================================
 # SPECIFIC UPGRADE
@@ -195,7 +194,7 @@ ynh_add_fpm_config --phpversion=$phpversion --usage=$fpm_usage --footprint=$fpm_
 #=================================================
 ynh_script_progression --message="Updating composer dependencies..."
 
-ynh_exec_warn_less ynh_composer_exec --phpversion="$phpversion" --workdir="$final_path" --commands="update"
+ynh_exec_warn_less ynh_composer_exec --workdir="$final_path" --commands="update"
 
 #=================================================
 # UPDATE A CONFIG FILE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -173,19 +173,19 @@ ynh_script_progression --message="Upgrading NGINX web server configuration..."
 ynh_add_nginx_config
 
 #=================================================
+# UPGRADE DEPENDENCIES
+#=================================================
+ynh_script_progression --message="Upgrading dependencies..."
+
+ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
+
+#=================================================
 # PHP-FPM CONFIGURATION
 #=================================================
 ynh_script_progression --message="Upgrading PHP-FPM configuration..."
 
 # Create a dedicated PHP-FPM config
 ynh_add_fpm_config --usage=$fpm_usage --footprint=$fpm_footprint
-
-#=================================================
-# UPGRADE DEPENDENCIES
-#=================================================
-ynh_script_progression --message="Upgrading dependencies..."
-
-ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================
 # SPECIFIC UPGRADE


### PR DESCRIPTION
## Problem

- A new Pixelfed version is available : v0.11.2 https://github.com/pixelfed/pixelfed/releases/tag/v0.11.2
- Php 7.3 is no longer supported https://github.com/pixelfed/pixelfed/pull/3041

## Solution

- Upgrade Pixelfed
- Switch to php 7.4

## PR Status

**Pending until Pixelfed version is released** : I wanted to keep in mind that we would need to upgrade PHP version… that's why I made that draft

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
- [x] Upgrade from previous installation (using php7.3) as been tested

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
