### PR TITLE
Specify PHP version for Redis and Imagick deps

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
         }
     ],
     "requirements": {
-        "yunohost": ">= 4.3.0"
+        "yunohost": ">= 11.0"
     },
     "multi_instance": true,
     "services": [

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,7 +8,7 @@ YNH_PHP_VERSION="7.4"
 
 YNH_COMPOSER_VERSION="2.1.5"
 
-pkg_dependencies="postgresql libgd3 jpegoptim optipng pngquant ffmpeg imagemagick supervisor php-redis php${YNH_PHP_VERSION}-bcmath php${YNH_PHP_VERSION}-cli php${YNH_PHP_VERSION}-ctype php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-exif php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-iconv php${YNH_PHP_VERSION}-intl php${YNH_PHP_VERSION}-json php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-tokenizer php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-zip php${YNH_PHP_VERSION}-pdo php${YNH_PHP_VERSION}-pgsql php${YNH_PHP_VERSION}-fileinfo php-imagick"
+pkg_dependencies="postgresql libgd3 jpegoptim optipng pngquant ffmpeg imagemagick supervisor php${YNH_PHP_VERSION}-redis php${YNH_PHP_VERSION}-bcmath php${YNH_PHP_VERSION}-cli php${YNH_PHP_VERSION}-ctype php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-exif php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-iconv php${YNH_PHP_VERSION}-intl php${YNH_PHP_VERSION}-json php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-tokenizer php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-zip php${YNH_PHP_VERSION}-pdo php${YNH_PHP_VERSION}-pgsql php${YNH_PHP_VERSION}-fileinfo php${YNH_PHP_VERSION}-imagick"
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
Would help alleviate situations like this : https://forum.yunohost.org/t/nextcloud-does-not-install/21383 and log https://paste.yunohost.org/raw/ojojixukag

⚠️ Bumps YunoHost requirement to 11

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
