### PR TITLE
Upgrade composer to v2 (fix broken script + php8.0 compatibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In addition to taking over the functionality of Instagram, the functioning of Pi
 
 It is also possible to import your data from Instagram. 
 
-**Shipped version:** 0.11.4~ynh3
+**Shipped version:** 0.11.4~ynh4
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -25,7 +25,7 @@ En plus de reprendre les fonctionnalités d'Instagram, le fonctionnement de Pixe
 Il est également possible d'importer ses données depuis Instagram.
 
 
-**Version incluse :** 0.11.4~ynh3
+**Version incluse :** 0.11.4~ynh4
 
 ## Captures d'écran
 

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -8,7 +8,7 @@ After being first registered, you need to execute the folloing command to promot
 
 **Run:**
 
-    $ sudo php7.4 /var/www/pixelfed/artisan user:admin 1
+    $ sudo php8.0 /var/www/pixelfed/artisan user:admin 1
 
 and respond yes to the question ` Add admin privileges to this user?`.
 

--- a/doc/DISCLAIMER_fr.md
+++ b/doc/DISCLAIMER_fr.md
@@ -8,7 +8,7 @@ Après avoir été enregistré pour la première fois, vous devez exécuter la c
 
 **Entrez la commande:**
 
-    $ php7.4 /var/www/pixelfed/artisan user:admin 1
+    $ php8.0 /var/www/pixelfed/artisan user:admin 1
 
 et répondez oui à la question « Ajouter des privilèges d'administrateur à cet utilisateur ? »
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "ActivityPub Federated Image Sharing",
         "fr": "Logiciel de partage d'image fédéré via ActivityPub"
     },
-    "version": "0.11.4~ynh3",
+    "version": "0.11.4~ynh4",
     "url": "https://pixelfed.org/",
     "upstream": {
         "license": "AGPL-3.0-or-later",

--- a/scripts/install
+++ b/scripts/install
@@ -125,7 +125,7 @@ ynh_add_nginx_config
 #=================================================
 ynh_script_progression --message="Installing composer dependencies..." --weight=1
 
-ynh_exec_warn_less ynh_install_composer --phpversion="$phpversion" --workdir="$final_path"
+ynh_exec_warn_less ynh_install_composer --phpversion="$phpversion" --composerversion="$YNH_COMPOSER_VERSION" --workdir="$final_path"
 
 #=================================================
 # CREATE LOG FILE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -185,7 +185,7 @@ ynh_add_nginx_config
 #=================================================
 ynh_script_progression --message="Updating composer..." --weight=1
 
-ynh_exec_warn_less ynh_composer_exec --workdir="$final_path" --commands="self-update --2"
+ynh_exec_warn_less ynh_composer_exec --workdir="$final_path" --commands="self-update"
 
 ynh_script_progression --message="Updating composer dependencies..." --weight=1
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -183,6 +183,10 @@ ynh_add_nginx_config
 #=================================================
 # UPDATE COMPOSER DEPENDENCIES
 #=================================================
+ynh_script_progression --message="Updating composer..." --weight=1
+
+ynh_exec_warn_less ynh_composer_exec --workdir="$final_path" --commands="self-update --2"
+
 ynh_script_progression --message="Updating composer dependencies..." --weight=1
 
 ynh_exec_warn_less ynh_composer_exec --workdir="$final_path" --commands="update"


### PR DESCRIPTION
## Problem

- #196 
- 
## Solution

- Composer version wasn't used.
- self-upgrade to v2 before updating dependencies

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
