### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -7,7 +7,7 @@ source /usr/share/yunohost/helpers
 # INITIALIZE AND STORE SETTINGS
 #=================================================
 
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 app_key="base64:$(ynh_string_random --length=32 | base64)"
 
 ynh_app_setting_set --key=app_key --value=$app_key

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -3,7 +3,7 @@
 source _common.sh
 source /usr/share/yunohost/helpers
 
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 ynh_app_setting_set_default --key=language --value="fr"
 ynh_app_setting_set_default --key=php_upload_max_filesize --value=100M
 ynh_app_setting_set_default --key=php_post_max_size --value=100M


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.