### PR TITLE
Allow for profile / post embedding

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,3 +1,6 @@
+#Allow for embedding of profiles/posts etc. 
+more_set_headers "X-Frame-Options : ALLOWALL";
+
 #sub_path_only rewrite ^__PATH__$ __PATH__/ permanent;
 location __PATH__/ {
 


### PR DESCRIPTION
Similar to the setting for PeerTube this change allows for the embed feature of profiles and posts to work.

## Problem

The embed feature of Pixelfed does not work as the X-Frame-Options always default to sameorigin.  

## Solution

Due to the security setup of yunohost this was the only solution copied from the PeerTube setup that changes the X-Frame-Options header to allowall. Embedding can still be switched off from the Admin panel in Pixelfed. 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
