### PR TITLE
Update version numbering and commenting out github autoupdate

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Pixelfed"
 description.en = "Decentralized photo sharing social media platform"
 description.fr = "Plateforme de partage de photos décentralisée"
 
-version = "2026.01.10~ynh1"
+version = "0.12.6~ynh3"
 
 maintainers = ["yalh76", "Lapineige"]
 
@@ -50,7 +50,7 @@ ram.runtime = "100M"
         [resources.sources.main]
         url = "https://github.com/pixelfed/pixelfed/archive/47b33b0a2933a8ad6f57c48d32f2996f72ab07a4.tar.gz"
         sha256 = "5f994101a55951cd26ce6cb45b6a78412310bf4401a8b22e9e8aa43f9d2b5cb7"
-        autoupdate.strategy = "latest_github_commit"
+#        autoupdate.strategy = "latest_github_release"
 
     [resources.system_user]
     allow_email = true


### PR DESCRIPTION
## Problem

- Updating the version numbering to stay consistent
- Commenting out the github automation for new commit/new release. Can be reinstated after next release 

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
