### PR TITLE
Upload max filesize

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -10,7 +10,7 @@ location __PATH__/ {
   index index.php;
 
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
-  client_max_body_size __PHP_POST_MAX_SIZE__;
+  client_max_body_size __PHP_UPLOAD_MAX_FILESIZE__;
 
   try_files $uri $uri/ @pixelfed;
   location ~ [^/]\.php(/|$) {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -10,7 +10,7 @@ location __PATH__/ {
   index index.php;
 
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
-  client_max_body_size __PHP_UPLOAD_MAX_FILESIZE__;
+  client_max_body_size __PHP_POST_MAX_SIZE__;
 
   try_files $uri $uri/ @pixelfed;
   location ~ [^/]\.php(/|$) {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -10,7 +10,7 @@ location __PATH__/ {
   index index.php;
 
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
-  client_max_body_size 100M;
+  client_max_body_size __PHP_UPLOAD_MAX_FILESIZE__;
 
   try_files $uri $uri/ @pixelfed;
   location ~ [^/]\.php(/|$) {

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -10,14 +10,9 @@ name.en = "Upload limit size"
 name.fr = "Téléchargement de fichiers"
 
 [main.limit_size.php_upload_max_filesize]
-ask.fr = "Taille limite d'un fichier en Mo"
-ask.en = "Size limit file upload (Mb)"
+ask.fr = "Taille limite d'un téléchargement en Mo"
+ask.en = "Upload size limit (Mb)"
 type = "number"
 bind = "null"
 
-[main.limit_size.php_post_max_size]
-ask.fr = "Taille limite d'un envoi en Mo"
-ask.en = "Size limit post upload (Mb)"
-type = "number"
-bind = "null"
 

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -1,0 +1,23 @@
+version = "1.0"
+
+[main]
+name.en = "Configuration panel"
+name.fr = "Panneau de configuration"
+services = ["__APP__", "nginx"]
+
+[main.limit_size]
+name.en = "Upload limit size"
+name.fr = "Téléchargement de fichiers"
+
+[main.limit_size.php_upload_max_filesize]
+ask.fr = "Taille limite d'un fichier en Mo"
+ask.en = "Size limit file upload (Mb)"
+type = "number"
+bind = "null"
+
+[main.limit_size.php_post_max_size]
+ask.fr = "Taille limite d'un envoi en Mo"
+ask.en = "Size limit post upload (Mb)"
+type = "number"
+bind = "null"
+

--- a/manifest.toml
+++ b/manifest.toml
@@ -6,7 +6,7 @@ description.en = "Decentralized photo sharing social media platform"
 description.fr = "Plateforme de partage de photos décentralisée"
 
 
-version = "0.12.6~ynh2"
+version = "0.12.6~ynh3"
 
 maintainers = ["yalh76", "Lapineige"]
 

--- a/scripts/config
+++ b/scripts/config
@@ -6,7 +6,6 @@ ynh_app_setting_get --key=php_upload_max_filesize  | sed 's/M$//' # number requi
 }
 
 set__php_upload_max_filesize() {
-    ynh_config_remove_phpfpm
     ynh_replace --match='client_max_body_size [^"]*' --replace="client_max_body_size  ${php_upload_max_filesize}M  ;" --file="/etc/nginx/conf.d/$domain.d/$app.conf"
     ynh_store_file_checksum "/etc/nginx/conf.d/$domain.d/$app.conf"
     ynh_app_setting_set --key=php_post_max_size --value="${php_upload_max_filesize}M"

--- a/scripts/config
+++ b/scripts/config
@@ -1,0 +1,26 @@
+#!/bin/bash
+source /usr/share/yunohost/helpers
+
+get__php_upload_max_filesize() {
+ynh_app_setting_get --key=php_upload_max_filesize
+}
+get__php_post_max_size() {
+ynh_app_setting_get --key=php_post_max_size
+}
+
+
+set__php_post_max_size() {
+    ynh_replace --match='client_max_body_size [^"]*' --replace="client_max_body_size  ${php_post_max_size}M  ;" --file="/etc/nginx/conf.d/$domain.d/$app.conf"
+    ynh_store_file_checksum "/etc/nginx/conf.d/$domain.d/$app.conf"
+    ynh_app_setting_set --key=php_post_max_size --value="$php_post_max_size.M"
+    ynh_print_info "The nginx config has been edited"
+}
+
+set__php_upload_max_filesize() {
+    ynh_app_setting_set --key=php_upload_max_filesize --value="$php_upload_max_filesize"
+    ynh_print_info "The nginx config has been edited"
+}
+
+
+ynh_abort_if_errors
+ynh_app_config_run $1

--- a/scripts/config
+++ b/scripts/config
@@ -2,25 +2,19 @@
 source /usr/share/yunohost/helpers
 
 get__php_upload_max_filesize() {
-ynh_app_setting_get --key=php_upload_max_filesize
-}
-get__php_post_max_size() {
-ynh_app_setting_get --key=php_post_max_size
-}
-
-
-set__php_post_max_size() {
-    ynh_replace --match='client_max_body_size [^"]*' --replace="client_max_body_size  ${php_post_max_size}M  ;" --file="/etc/nginx/conf.d/$domain.d/$app.conf"
-    ynh_store_file_checksum "/etc/nginx/conf.d/$domain.d/$app.conf"
-    ynh_app_setting_set --key=php_post_max_size --value="${php_post_max_size}M"
-    ynh_print_info "The nginx config has been edited"
+ynh_app_setting_get --key=php_upload_max_filesize  | sed 's/M$//' # number required in config panel
 }
 
 set__php_upload_max_filesize() {
+    ynh_config_remove_phpfpm
+    ynh_replace --match='client_max_body_size [^"]*' --replace="client_max_body_size  ${php_upload_max_filesize}M  ;" --file="/etc/nginx/conf.d/$domain.d/$app.conf"
+    ynh_store_file_checksum "/etc/nginx/conf.d/$domain.d/$app.conf"
+    ynh_app_setting_set --key=php_post_max_size --value="${php_upload_max_filesize}M"
     ynh_app_setting_set --key=php_upload_max_filesize --value="${php_upload_max_filesize}M"
-    ynh_print_info "The nginx config has been edited"
+    php_upload_max_filesize=$(ynh_app_setting_get --key=php_upload_max_filesize) # update php_upload_max_filesize
+    ynh_config_add_phpfpm
+    ynh_print_info "upload max file size has been updated"
 }
-
 
 ynh_abort_if_errors
 ynh_app_config_run $1

--- a/scripts/config
+++ b/scripts/config
@@ -12,12 +12,12 @@ ynh_app_setting_get --key=php_post_max_size
 set__php_post_max_size() {
     ynh_replace --match='client_max_body_size [^"]*' --replace="client_max_body_size  ${php_post_max_size}M  ;" --file="/etc/nginx/conf.d/$domain.d/$app.conf"
     ynh_store_file_checksum "/etc/nginx/conf.d/$domain.d/$app.conf"
-    ynh_app_setting_set --key=php_post_max_size --value="$php_post_max_size.M"
+    ynh_app_setting_set --key=php_post_max_size --value="${php_post_max_size}M"
     ynh_print_info "The nginx config has been edited"
 }
 
 set__php_upload_max_filesize() {
-    ynh_app_setting_set --key=php_upload_max_filesize --value="$php_upload_max_filesize"
+    ynh_app_setting_set --key=php_upload_max_filesize --value="${php_upload_max_filesize}"
     ynh_print_info "The nginx config has been edited"
 }
 

--- a/scripts/config
+++ b/scripts/config
@@ -17,7 +17,7 @@ set__php_post_max_size() {
 }
 
 set__php_upload_max_filesize() {
-    ynh_app_setting_set --key=php_upload_max_filesize --value="${php_upload_max_filesize}"
+    ynh_app_setting_set --key=php_upload_max_filesize --value="${php_upload_max_filesize}M"
     ynh_print_info "The nginx config has been edited"
 }
 

--- a/scripts/install
+++ b/scripts/install
@@ -12,7 +12,7 @@ app_key="base64:$(ynh_string_random --length=32 | base64)"
 
 ynh_app_setting_set --key=app_key --value=$app_key
 ynh_app_setting_set_default --key=php_upload_max_filesize --value=100M
-ynh_app_setting_set_default --key=php_post_max_size --value=101M
+ynh_app_setting_set --key=php_post_max_size --value=100M
 ynh_app_setting_set --key=php_max_file_uploads --value=20
 ynh_app_setting_set --key=php_max_execution_time --value=600
 

--- a/scripts/install
+++ b/scripts/install
@@ -11,8 +11,8 @@ timezone=$(timedatectl show --value --property=Timezone)
 app_key="base64:$(ynh_string_random --length=32 | base64)"
 
 ynh_app_setting_set --key=app_key --value=$app_key
-ynh_app_setting_set --key=php_upload_max_filesize --value=100M
-ynh_app_setting_set --key=php_post_max_size --value=100M
+ynh_app_setting_set_default --key=php_upload_max_filesize --value=100M
+ynh_app_setting_set_default --key=php_post_max_size --value=100M
 ynh_app_setting_set --key=php_max_file_uploads --value=100M
 ynh_app_setting_set --key=php_max_execution_time --value=600
 

--- a/scripts/install
+++ b/scripts/install
@@ -12,8 +12,8 @@ app_key="base64:$(ynh_string_random --length=32 | base64)"
 
 ynh_app_setting_set --key=app_key --value=$app_key
 ynh_app_setting_set_default --key=php_upload_max_filesize --value=100M
-ynh_app_setting_set_default --key=php_post_max_size --value=100M
-ynh_app_setting_set --key=php_max_file_uploads --value=100M
+ynh_app_setting_set_default --key=php_post_max_size --value=101M
+ynh_app_setting_set --key=php_max_file_uploads --value=20
 ynh_app_setting_set --key=php_max_execution_time --value=600
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -4,11 +4,6 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 timezone=$(timedatectl show --value --property=Timezone)
-ynh_app_setting_set_default --key=language --value="fr"
-ynh_app_setting_set_default --key=php_upload_max_filesize --value=100M
-ynh_app_setting_set_default --key=php_post_max_size --value=100M
-ynh_app_setting_set_default --key=php_max_file_uploads --value=20
-ynh_app_setting_set_default --key=php_max_execution_time --value=600
 
 #=================================================
 # STOP SYSTEMD SERVICE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -7,7 +7,7 @@ timezone=$(timedatectl show --value --property=Timezone)
 ynh_app_setting_set_default --key=language --value="fr"
 ynh_app_setting_set_default --key=php_upload_max_filesize --value=100M
 ynh_app_setting_set_default --key=php_post_max_size --value=100M
-ynh_app_setting_set_default --key=php_max_file_uploads --value=100M
+ynh_app_setting_set_default --key=php_max_file_uploads --value=20
 ynh_app_setting_set_default --key=php_max_execution_time --value=600
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -4,6 +4,7 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 timezone=$(timedatectl show --value --property=Timezone)
+ynh_app_setting_set --key=php_max_file_uploads --value=20
 
 #=================================================
 # STOP SYSTEMD SERVICE

--- a/tests.toml
+++ b/tests.toml
@@ -8,4 +8,4 @@ exclude = [ "change_url" ]
     # Commits to test upgrade from
     # -------------------------------
 
-    test_upgrade_from.aa1c6c9.name = "Upgrade from v0.11.9"
+  # test_upgrade_from.aa1c6c9.name = "Upgrade from v0.11.9"


### PR DESCRIPTION
## Problem

Issue with upload file size :
https://forum.yunohost.org/t/pixelfed-video-size-limits/41437
* php-fpm settings only can be updated upgrading
* hard-coded nginx  client_max_body_size setting 
## Solution
- Fix
- Adding a config panel to set custom upload max size
## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
